### PR TITLE
Rebrand integration to `aromalink_ha_integration` and harden device/state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This custom component integrates Aroma-Link WiFi diffusers with Home Assistant.
 
 > **Note:** The integration appears in Home Assistant as `Aromalink Integration` with the domain `aromalink_ha_integration`.
 
-> **1.9 upgrade note:** Version `1.9.0` rebrands the integration domain from `aromalink_integration_v1` to `aromalink_ha_integration`. Existing config entries from `aroma_link_integration`, `dalyem_aroma_link`, `ha_aromalink`, and `aromalink_integration_v1` are not migrated automatically.
+> **2.0 upgrade note:** Version `2.0.0` rebrands the integration domain from `aromalink_integration_v1` to `aromalink_ha_integration`. Existing config entries from `aroma_link_integration`, `dalyem_aroma_link`, `ha_aromalink`, and `aromalink_integration_v1` are not migrated automatically.
 
 ![Aroma-Link logo](brand/logo.png)
 
@@ -17,7 +17,7 @@ This custom component integrates Aroma-Link WiFi diffusers with Home Assistant.
 - Auto-discover all devices on your Aroma-Link account
 - Configure the polling interval from Home Assistant
 
-## Migration to 1.9.0
+## Migration to 2.0.0
 
 1. Update the repository in HACS or replace the manual install folder with `custom_components/aromalink_ha_integration`.
 2. Restart Home Assistant.
@@ -59,6 +59,20 @@ cp -r custom_components/aromalink_ha_integration <home_assistant_config>/custom_
 3. Search for `Aromalink Integration`.
 4. Enter your Aroma-Link username and password.
 5. Home Assistant will discover all supported devices on the account.
+
+## Options and Settings
+
+- Polling interval default: `60` seconds
+- Polling interval minimum: `10` seconds
+- Polling interval maximum: `300` seconds
+- Polling interval step: `10` seconds
+- Where to change it: Open the integration and edit the `Polling Interval` control
+- Work duration minimum: `5` seconds
+- Work duration maximum: `900` seconds
+- Work duration step: `1` second
+- Pause duration minimum: `5` seconds
+- Pause duration maximum: `900` seconds
+- Pause duration step: `5` seconds
 
 ## Services
 
@@ -128,7 +142,7 @@ Useful options:
 
 ## Version History
 
-- `1.9.0`: Rebranded to the `aromalink_ha_integration` domain and `Aromalink Integration` name, added migration guidance, and removed secret-adjacent debug logging
+- `2.0.0`: Rebranded to the `aromalink_ha_integration` domain and `Aromalink Integration` name, added migration guidance, and removed secret-adjacent debug logging
 - `1.5.8`: Changed the default work/pause values to `10 / 90`
 - `1.5.7`: Added a user-configurable polling interval option and improved runtime consistency
 - `1.5.6`: Switched runtime fallback to the working web device-list endpoints and added the local probe script

--- a/custom_components/aromalink_ha_integration/manifest.json
+++ b/custom_components/aromalink_ha_integration/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dalyem/ha_aromalink/issues",
   "loggers": ["custom_components.aromalink_ha_integration"],
   "requirements": [],
-  "version": "1.9.0"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
## Summary
- Rename the Home Assistant integration domain/package from `aromalink_integration_v1` to `aromalink_ha_integration` and update branding/assets/metadata for the new identity.
- Bump release metadata through `1.9.0` and `2.0.0`, including README migration guidance for existing users and updated service/entity docs.
- Add config-entry option reload support so polling interval changes take effect via integration reload.
- Add/expand number and sensor handling for polling interval and normalized runtime/count fields across API payload variants.
- Improve device-state fallback behavior by merging web list responses and normalizing count aliases (`onCount`/`runCount`/`openCount`, `pumpCount`/`airPumpCount`/`pumpTimes`).
- Remove trace-style request/response/token logging paths and reduce sensitive auth/debug output.
- Extend `scripts/aromalink_probe.py` output to summarize probe counts and merged fallback data.

## Testing
- Not run (no automated test suite changes included in this branch).
- Verified diff coverage includes domain/path rename updates across component package, manifest, HACS metadata, and docs.
- Confirmed config entry now registers an update listener that reloads the entry when options change.
- Confirmed coordinator normalization now maps alternate count keys and populates canonical `onCount`/`pumpCount` fields in `raw_device_data`.