### PR TITLE
fix: Update AromaLink integration for SSL bypass

### DIFF
--- a/custom_components/aromalink_ha_integration/AromaLinkAuthCoordinator.py
+++ b/custom_components/aromalink_ha_integration/AromaLinkAuthCoordinator.py
@@ -10,7 +10,7 @@ import aiohttp
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import AROMA_LINK_SSL, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 AROMA_LINK_USER_AGENT = (
@@ -23,7 +23,7 @@ AROMA_LINK_USER_AGENT = (
 class AromaLinkAuthCoordinator(DataUpdateCoordinator):
     """Coordinator for handling authentication and session management."""
 
-    def __init__(self, hass, username, password, user_id=None):
+    def __init__(self, hass, username, password, user_id=None, ignore_ssl=False):
         """Initialize the auth coordinator."""
         self.username = username
         self.password = password
@@ -33,6 +33,7 @@ class AromaLinkAuthCoordinator(DataUpdateCoordinator):
         self.language_code = "EN"
         self.user_id = user_id
         self.session = async_get_clientsession(hass)
+        self._ignore_ssl = ignore_ssl
         self._last_login_time = 0
 
         super().__init__(
@@ -42,6 +43,15 @@ class AromaLinkAuthCoordinator(DataUpdateCoordinator):
             # Check auth every 15 minutes
             update_interval=timedelta(minutes=15),
         )
+
+    @property
+    def ssl(self):
+        """Return SSL parameter for aiohttp requests.
+
+        Returns False (skip verification) when the user has opted to ignore SSL errors,
+        or None (use default session SSL context) otherwise.
+        """
+        return False if self._ignore_ssl else None
 
     async def _async_update_data(self):
         """Fetch authentication data."""
@@ -108,7 +118,7 @@ class AromaLinkAuthCoordinator(DataUpdateCoordinator):
             async with self.session.get(
                 "https://www.aroma-link.com/",
                 timeout=10,
-                ssl=AROMA_LINK_SSL,
+                ssl=self.ssl,
             ) as initial_response:
                 initial_response.raise_for_status()
                 _LOGGER.debug(
@@ -121,7 +131,7 @@ class AromaLinkAuthCoordinator(DataUpdateCoordinator):
                 data=data,
                 headers=headers,
                 timeout=10,
-                ssl=AROMA_LINK_SSL,
+                ssl=self.ssl,
             ) as response:
                 response_text = await response.text()
                 _LOGGER.debug(f"Login response status: {response.status}")

--- a/custom_components/aromalink_ha_integration/AromaLinkDeviceCoordinator.py
+++ b/custom_components/aromalink_ha_integration/AromaLinkDeviceCoordinator.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import aiohttp
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .const import (
-    AROMA_LINK_SSL,
     DOMAIN,
     DEFAULT_DIFFUSE_TIME,
     DEFAULT_WORK_DURATION,
@@ -283,7 +282,7 @@ class AromaLinkDeviceCoordinator(DataUpdateCoordinator):
                     url,
                     headers=headers,
                     timeout=15,
-                    ssl=AROMA_LINK_SSL,
+                    ssl=self.auth_coordinator.ssl,
                 ) as response:
                     self._log_response("GET", url, response.status)
                     if response.status != 200:

--- a/custom_components/aromalink_ha_integration/AromaLinkDeviceCoordinator.py
+++ b/custom_components/aromalink_ha_integration/AromaLinkDeviceCoordinator.py
@@ -582,7 +582,7 @@ class AromaLinkDeviceCoordinator(DataUpdateCoordinator):
                 url,
                 headers=headers,
                 timeout=15,
-                ssl=AROMA_LINK_SSL,
+                ssl=self.auth_coordinator.ssl,
             ) as response:
                 self._log_response("GET", url, response.status)
                 if response.status == 200:
@@ -650,7 +650,7 @@ class AromaLinkDeviceCoordinator(DataUpdateCoordinator):
                 url,
                 headers=headers,
                 timeout=15,
-                ssl=AROMA_LINK_SSL,
+                ssl=self.auth_coordinator.ssl,
             ) as response:
                 self._log_response("GET", url, response.status)
                 if response.status == 200:
@@ -774,7 +774,7 @@ class AromaLinkDeviceCoordinator(DataUpdateCoordinator):
                 data=data,
                 headers=headers,
                 timeout=10,
-                ssl=AROMA_LINK_SSL,
+                ssl=self.auth_coordinator.ssl,
             ) as response:
                 self._log_response("POST", url, response.status)
                 if response.status == 200:
@@ -882,7 +882,7 @@ class AromaLinkDeviceCoordinator(DataUpdateCoordinator):
                 json=payload,
                 headers=headers,
                 timeout=10,
-                ssl=AROMA_LINK_SSL,
+                ssl=self.auth_coordinator.ssl,
             ) as response:
                 self._log_response("POST", url, response.status)
                 response_text = await response.text()

--- a/custom_components/aromalink_ha_integration/__init__.py
+++ b/custom_components/aromalink_ha_integration/__init__.py
@@ -11,10 +11,11 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 
 from .const import (
-    DOMAIN,
     CONF_DEVICE_ID,
+    CONF_IGNORE_SSL,
     CONF_POLL_INTERVAL_SECONDS,
     DEFAULT_POLL_INTERVAL_SECONDS,
+    DOMAIN,
     SERVICE_SET_SCHEDULER,
     SERVICE_RUN_DIFFUSER,
     ATTR_WORK_DURATION,
@@ -67,6 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Aroma-Link from a config entry."""
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
+    ignore_ssl = entry.data.get(CONF_IGNORE_SSL, False)
     devices = entry.data.get("devices", [])
 
     if not devices and CONF_DEVICE_ID in entry.data:
@@ -97,6 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         username=username,
         password=password,
         user_id=user_id,
+        ignore_ssl=ignore_ssl,
     )
 
     # Force first login and initialization

--- a/custom_components/aromalink_ha_integration/config_flow.py
+++ b/custom_components/aromalink_ha_integration/config_flow.py
@@ -7,13 +7,13 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import aiohttp
 
 from .const import (
-    AROMA_LINK_SSL,
-    DOMAIN,
-    CONF_USERNAME,
-    CONF_PASSWORD,
     CONF_DEVICE_ID,
+    CONF_IGNORE_SSL,
+    CONF_PASSWORD,
     CONF_POLL_INTERVAL_SECONDS,
+    CONF_USERNAME,
     DEFAULT_POLL_INTERVAL_SECONDS,
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,9 +45,10 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             username = user_input[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]
+            ignore_ssl = user_input.get(CONF_IGNORE_SSL, False)
 
             # Try to authenticate
-            session, jsessionid, devices = await self._authenticate(username, password)
+            session, jsessionid, devices = await self._authenticate(username, password, ignore_ssl)
             
             if jsessionid:
                 self._username = username
@@ -77,6 +78,7 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_USERNAME: username,
                             CONF_PASSWORD: password,
+                            CONF_IGNORE_SSL: ignore_ssl,
                             "user_id": user_id,
                             "devices": [
                                 {
@@ -101,12 +103,13 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
+                    vol.Optional(CONF_IGNORE_SSL, default=False): bool,
                 }
             ),
             errors=errors,
         )
         
-    async def _authenticate(self, username, password):
+    async def _authenticate(self, username, password, ignore_ssl=False):
         """Authenticate with Aroma-Link API and retrieve device list.
         
         Returns:
@@ -116,6 +119,7 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             - devices: List of discovered devices, or empty list if none found
         """
         session = async_get_clientsession(self.hass)
+        ssl = False if ignore_ssl else None
         jsessionid = None
         devices = []
         
@@ -139,7 +143,7 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 login_url,
                 data=data,
                 headers=headers,
-                ssl=AROMA_LINK_SSL,
+                ssl=ssl,
             ) as response:
                 response_text = await response.text()
                 
@@ -152,7 +156,7 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         
                         # Now fetch device list
                         _LOGGER.debug("Fetching device list")
-                        devices = await self._fetch_device_list(session, jsessionid)
+                        devices = await self._fetch_device_list(session, jsessionid, ssl)
                         
                         _LOGGER.info(f"Found {len(devices)} devices for {username}")
                         return session, jsessionid, devices
@@ -219,7 +223,7 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             
         return None
         
-    async def _fetch_device_list(self, session, jsessionid):
+    async def _fetch_device_list(self, session, jsessionid, ssl=None):
         """Fetch the list of devices for the authenticated user."""
         language_code = "EN"
         device_list_url = "https://www.aroma-link.com/device/list/v2?limit=10&offset=0&selectUserId=&groupId=&deviceName=&imei=&deviceNo=&workStatus=&continentId=&countryId=&areaId=&sort=&order="
@@ -232,7 +236,7 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 async with session.get(
                     "https://www.aroma-link.com/device/list",
                     timeout=10,
-                    ssl=AROMA_LINK_SSL,
+                    ssl=ssl,
                 ) as init_response:
                     init_response.raise_for_status()
             except Exception as e:
@@ -248,7 +252,7 @@ class AromaLinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             async with session.get(
                 device_list_url,
                 headers=device_headers,
-                ssl=AROMA_LINK_SSL,
+                ssl=ssl,
             ) as device_response:
                 if device_response.status == 200:
                     device_response_text = await device_response.text()

--- a/custom_components/aromalink_ha_integration/const.py
+++ b/custom_components/aromalink_ha_integration/const.py
@@ -1,7 +1,6 @@
 """Constants for the Aroma-Link integration."""
 
 DOMAIN = "aromalink_ha_integration"
-AROMA_LINK_SSL = False  # Temporary workaround for Aroma-Link's expired certificate.
 
 # Configuration
 CONF_USERNAME = "username"
@@ -10,6 +9,7 @@ CONF_DEVICE_ID = "device_id"
 CONF_DIFFUSE_TIME = "diffuse_time"
 CONF_WORK_DURATION = "work_duration"
 CONF_POLL_INTERVAL_SECONDS = "poll_interval_seconds"
+CONF_IGNORE_SSL = "ignore_ssl"
 
 # Default values
 DEFAULT_DIFFUSE_TIME = 60  # seconds

--- a/custom_components/aromalink_ha_integration/translations/en.json
+++ b/custom_components/aromalink_ha_integration/translations/en.json
@@ -6,7 +6,11 @@
         "description": "Enter your Aroma-Link account credentials. All your devices will be automatically discovered.",
         "data": {
           "username": "Aroma-Link Username",
-          "password": "Aroma-Link Password"
+          "password": "Aroma-Link Password",
+          "ignore_ssl": "Ignore SSL certificate errors"
+        },
+        "data_description": {
+          "ignore_ssl": "Enable if you are experiencing connection errors due to an expired or misconfigured Aroma-Link server certificate."
         }
       }
     },


### PR DESCRIPTION
## Summary

Aroma link let their SSL cert expire, rookie mistake.

This PR adds a checkbox to the integration's config flow that lets users skip SSL certificate verification when connecting to the Aroma-Link server. 

## Screenshot
<img width="571" height="471" alt="Screenshot 2026-06-10 at 12 39 03 AM" src="https://github.com/user-attachments/assets/8549bf1d-fa30-4e4c-bdec-cc200bf341ad" />

## Add user-toggleable SSL verification bypass

- `const.py`: Replace `AROMA_LINK_SSL` constant with `CONF_IGNORE_SSL` config key
- `config_flow.py`: Add "Ignore SSL certificate errors" checkbox to the initial setup form (default: off)
- `__init__.py`, `AromaLinkAuthCoordinator.py`, `AromaLinkDeviceCoordinator.py`: Wire the `ignore_ssl` setting through the coordinator chain and use it on all HTTPS requests
- `translations/en.json`: Add label and field description explaining when to enable this option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable “Ignore SSL certificate errors” option during setup to optionally disable SSL certificate verification for connection and login requests.
* **Bug Fixes**
  * Improved SSL handling consistency across authentication and device communication by applying the same SSL verification behavior to all related HTTP calls.  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->