### PR TITLE
fix: restore On Count and Pump Count sensors with long-term statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ The integration creates:
 - **Fan switch** — Controls the exhaust fan independently of oil pumping. Use to accelerate scent distribution without running the diffuser.
 - Button entities for run/save actions
 - Number entities for work duration, pause duration, and polling interval
-- Sensor entities for runtime and device statistics
+- Sensor entities for runtime and device statistics:
+  - **Work Status**, **Work Remaining Time**, **Pause Remaining Time** — live cycle state.
+  - **Total Run Time** (hours) — the API's `runCount`, which accumulates seconds of work time.
+  - **Total Diffusion Time** (hours) — estimated as pump activations × current work duration.
+  - **On Count** / **Pump Count** — the raw API counters (long-term statistics enabled). The device pushes these upstream on its own schedule, so they typically update about once a day.
 
 ## Technical Notes
 

--- a/custom_components/aromalink_ha_integration/sensor.py
+++ b/custom_components/aromalink_ha_integration/sensor.py
@@ -1,6 +1,6 @@
 """Sensor platform for Aroma-Link."""
 import logging
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.const import UnitOfTime
@@ -23,8 +23,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entities.append(AromaLinkWorkRemainingTimeSensor(coordinator, entry, device_id, device_info["name"]))
         entities.append(AromaLinkPauseRemainingTimeSensor(coordinator, entry, device_id, device_info["name"]))
         entities.append(AromaLinkTotalRunTimeSensor(coordinator, entry, device_id, device_info["name"]))
+        entities.append(AromaLinkTotalDiffusionTimeSensor(coordinator, entry, device_id, device_info["name"]))
+        entities.append(AromaLinkOnCountSensor(coordinator, entry, device_id, device_info["name"]))
         entities.append(AromaLinkPumpCountSensor(coordinator, entry, device_id, device_info["name"]))
-    
+
     async_add_entities(entities)
 
 class AromaLinkSensorBase(CoordinatorEntity, SensorEntity):
@@ -196,17 +198,17 @@ class AromaLinkTotalRunTimeSensor(AromaLinkSensorBase):
         # runCount accumulates seconds of work time; convert to hours.
         return round(raw / 3600, 2)
 
-class AromaLinkPumpCountSensor(AromaLinkSensorBase):
+class AromaLinkTotalDiffusionTimeSensor(AromaLinkSensorBase):
     """Sensor showing total diffusion time in hours (airPumpCount * work_duration)."""
 
     def __init__(self, coordinator, entry, device_id, device_name):
-        """Initialize the pump count sensor."""
+        """Initialize the total diffusion time sensor."""
         super().__init__(
-            coordinator, 
-            entry, 
-            device_id, 
-            device_name, 
-            "Total Diffusion Time", 
+            coordinator,
+            entry,
+            device_id,
+            device_name,
+            "Total Diffusion Time",
             icon="mdi:spray-bottle",
             unit=UnitOfTime.HOURS
         )
@@ -224,7 +226,7 @@ class AromaLinkPumpCountSensor(AromaLinkSensorBase):
         )
         if pump_count is None:
             return None
-        
+
         work_duration = self.coordinator.work_duration or 0
         if work_duration <= 0:
             _LOGGER.debug(
@@ -232,7 +234,71 @@ class AromaLinkPumpCountSensor(AromaLinkSensorBase):
                 self._device_id, work_duration
             )
             return None
-        
+
         # airPumpCount counts activations; multiply by work duration to get total diffusion time.
         total_seconds = pump_count * work_duration
         return round(total_seconds / 3600, 2)
+
+class AromaLinkOnCountSensor(AromaLinkSensorBase):
+    """Raw counter the API reports for run activity (issue #2).
+
+    Keeps the pre-2.x unique_id, name, and unit so existing entities and
+    recorded history continue seamlessly. When served by the web list API
+    the underlying field is runCount, which accumulates seconds of work
+    time rather than a number of activations (see docs/API.md).
+    """
+
+    def __init__(self, coordinator, entry, device_id, device_name):
+        """Initialize the on count sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            device_id,
+            device_name,
+            "On Count",
+            icon="mdi:counter",
+            unit="activations"
+        )
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    @property
+    def native_value(self):
+        """Return the on count value."""
+        return self._get_raw_count(
+            "onCount",
+            "runCount",
+            "on_count",
+            "run_count",
+            "openCount",
+            "open_count",
+            "startCount",
+            "start_count",
+        )
+
+class AromaLinkPumpCountSensor(AromaLinkSensorBase):
+    """Raw pump activation counter (airPumpCount, +1 per completed cycle)."""
+
+    def __init__(self, coordinator, entry, device_id, device_name):
+        """Initialize the pump count sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            device_id,
+            device_name,
+            "Pump Count",
+            icon="mdi:shimmer",
+            unit="diffusions"
+        )
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    @property
+    def native_value(self):
+        """Return the pump count value."""
+        return self._get_raw_count(
+            "pumpCount",
+            "airPumpCount",
+            "pump_count",
+            "air_pump_count",
+            "pumpTimes",
+            "pump_times",
+        )


### PR DESCRIPTION
## Summary
Closes #2 — restores the raw **On Count** and **Pump Count** sensors that today's control reorganization (#33) replaced, and enables long-term statistics on them.

**Plan / write-up:** https://plan.dalem.dev/p/gpnehhje

## Context: where issue #2 actually stands
- The originally reported bug (counts imported once at setup, never updated) was **fixed in March**: the coordinator polls both device-list endpoints and merges them, and only the legacy v1 list carries `runCount`/`airPumpCount`. The reporter confirmed on 2026-03-28 that the counts update (~daily). Per `docs/API.md`, that daily-ish cadence is device-driven — the counters *"only update when the device pushes data upstream on its own schedule — cannot be forced via API"* — so it cannot be made faster from our side.
- However, PR #33 (merged today) **removed** On Count (→ Total Run Time) and repurposed Pump Count (→ Total Diffusion Time) under new unique_ids — on upgrade, the reporter's counter entities (473 activations / 92,705 diffusions at report time) would go dead.

## Changes
- Re-add `AromaLinkOnCountSensor` and `AromaLinkPumpCountSensor` **alongside** the derived time sensors (7 sensors per device), with the **original unique_ids, names, units, and icons** — existing entities, dashboards, automations, and recorded history resume seamlessly with identical values.
- Both raw counters get `state_class = TOTAL_INCREASING`, so HA now records proper long-term statistics (the reporter's use case is tracking activity over days); device-side counter resets are handled gracefully by that state class.
- Rename #33's `AromaLinkPumpCountSensor` class → `AromaLinkTotalDiffusionTimeSensor` (it computes diffusion time now, not a pump count). Internal-only: unique_ids derive from the sensor-type string, so no entity impact.
- README documents all sensors, including the semantics note from `docs/API.md` that the web API's `runCount` (surfaced by On Count) accumulates **work seconds**, not activations — the values have always been consistent; only the unit label is historical. Kept as-is deliberately: changing the unit would break statistics continuity for a cosmetic fix.

## Verification
Stubbed sensor tests, all passing: unique_ids match the pre-2.x registry format (`{user}_{device}_on_count` / `_pump_count`); raw values pass through unscaled (1,569,411 / 8,531 from the docs' sample payload); derived sensors unchanged (435.95 h / 23.7 h); `state_class` present on the raw counters only; missing data returns None without crashing. All files compile; hassfest + HACS on this PR.

**Hardware test for @dalyem:** after upgrading, On Count / Pump Count keep their entity_ids and prior magnitudes, and tick up when the device next pushes its report (~daily). Total Run Time / Total Diffusion Time continue alongside.

## Rollback
Single revertable commit, sensor platform + README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)