### PR TITLE
ci: ignore HACS license check until a license is chosen

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,3 +17,7 @@ jobs:
       - uses: hacs/action@main
         with:
           category: integration
+          # The repo has no LICENSE file (the upstream fork never had one), so
+          # the license check fails on in-repo branches while fork PRs skip it.
+          # Drop this ignore once a license is chosen and committed.
+          ignore: license


### PR DESCRIPTION
## Summary
Every push to master and every in-repo PR currently fails the `hacs` job with **"The repository has no license"** — including the two master pushes from today's merges. Fork PRs (like #32/#33) run a reduced HACS check set, which is why this never surfaced before.

The repo has never had a LICENSE file, and neither does the upstream Memberapple fork it derives from — so choosing a license is a maintainer decision I'm deliberately **not** making here (note the README's License section is also a no-warranty statement rather than a grant). This one-liner tells `hacs/action` to skip the license validation so CI reflects the actual state of the code.

## Follow-up for @dalyem
Pick and commit a license when you get a chance (MIT is the common choice for HA custom integrations — but since the upstream fork was unlicensed, whether/how to license is your call), then delete the `ignore: license` line. HACS docs on the requirement: https://hacs.xyz/docs/publish/include#check-license

## Verification
After merging, the `hacs` job on master pushes and in-repo PRs should pass again (8/8 remaining checks were already green — only license fails today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)